### PR TITLE
style: Format messages according to guide

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
             <h3>Message Structure</h3>
             <p>A commit messages consists of three distinct parts separated by a blank line: the title, an optional body and an optional footer. The layout looks like this:</p>
 
-            <pre><code>type: subject
+            <pre><code>type: Subject
 
 body
 
@@ -47,13 +47,13 @@ footer</code></pre>
             <p>The type is contained within the title and can be one of these types:</p>
 
             <ul>
-                <li><strong>feat:</strong> a new feature</li>
-                <li><strong>fix:</strong> a bug fix</li>
-                <li><strong>docs:</strong> changes to documentation</li>
-                <li><strong>style:</strong> formatting, missing semi colons, etc; no code change</li>
-                <li><strong>refactor:</strong> refactoring production code</li>
-                <li><strong>test:</strong> adding tests, refactoring test; no production code change</li>
-                <li><strong>chore:</strong> updating build tasks, package manager configs, etc; no production code change</li>
+                <li><strong>feat:</strong> A new feature</li>
+                <li><strong>fix:</strong> A bug fix</li>
+                <li><strong>docs:</strong> Changes to documentation</li>
+                <li><strong>style:</strong> Formatting, missing semi colons, etc; no code change</li>
+                <li><strong>refactor:</strong> Refactoring production code</li>
+                <li><strong>test:</strong> Adding tests, refactoring test; no production code change</li>
+                <li><strong>chore:</strong> Updating build tasks, package manager configs, etc; no production code change</li>
             </ul>
         </article>
 


### PR DESCRIPTION
I think it would be more intuitive if the type descriptions were formatted like the final commit messages should be (with a capital letter first).